### PR TITLE
Use OIDC to cleanup AWS S3 for branch deployments

### DIFF
--- a/.github/workflows/branch_deployments.yml
+++ b/.github/workflows/branch_deployments.yml
@@ -12,7 +12,6 @@ env:
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   ENABLE_FAST_DEPLOYS: 'true'
   DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
-
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
@@ -65,10 +64,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  s3_bucket_cleanup:
+    name: S3 Cleanup after branch deploy PR close
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-20.04
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::872515293554:role/gha-branch-deploys-s3
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: eu-west-2
       - name: Clean up S3 on close or merge
-        if: github.event.action == 'closed'
-        run:
-          aws s3 rm s3://bucket/ --recursive --exclude "*" --include "$GITHUB_HEAD_REF*"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 rm s3://weave.energy-branches/ --recursive --exclude "*" --include "$GITHUB_HEAD_REF*"


### PR DESCRIPTION
Trying to follow the details here: https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services to use OIDC instead of access keys. Note I realised it had to be a separate rather than a conditional step.