### PR TITLE
Aggregate SSEN raw data into monthly partitioned parquet files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 .dagster/*
 !.dagster/dagster.yaml
 data/**/*.csv
+data/**/*.parquet
 data/**/*.csv.gz
 .coverage
 coverage.xml

--- a/weave/assets/dno_lv_feeder_files.py
+++ b/weave/assets/dno_lv_feeder_files.py
@@ -27,7 +27,7 @@ def ssen_lv_feeder_files(
     ssen_api_client: SSENAPIClient,
 ) -> None:
     url = context.partition_key
-    filename = f"{ssen_api_client.filename_for_url(url)}.gz"
+    filename = f"{SSENAPIClient.filename_for_url(url)}.gz"
     with raw_files_resource.open(DNO.SSEN.value, filename, mode="wb") as f:
         ssen_api_client.download_file(context, url, f)
 

--- a/weave/assets/dno_lv_feeder_files.py
+++ b/weave/assets/dno_lv_feeder_files.py
@@ -8,7 +8,7 @@ from dagster import (
 )
 
 from ..core import DNO
-from ..resources.raw_files import RawFilesResource
+from ..resources.output_files import OutputFilesResource
 from ..resources.ssen import SSENAPIClient
 
 ssen_lv_feeder_files_partitions_def = DynamicPartitionsDefinition(
@@ -23,7 +23,7 @@ ssen_lv_feeder_files_partitions_def = DynamicPartitionsDefinition(
 )
 def ssen_lv_feeder_files(
     context: AssetExecutionContext,
-    raw_files_resource: RawFilesResource,
+    raw_files_resource: OutputFilesResource,
     ssen_api_client: SSENAPIClient,
 ) -> None:
     url = context.partition_key

--- a/weave/assets/dno_lv_feeder_monthly_parquet.py
+++ b/weave/assets/dno_lv_feeder_monthly_parquet.py
@@ -1,0 +1,101 @@
+import calendar
+from datetime import datetime
+
+import pyarrow as pa
+import pyarrow.csv as pa_csv
+import pyarrow.parquet as pq
+from dagster import (
+    AssetExecutionContext,
+    MonthlyPartitionsDefinition,
+    asset,
+    define_asset_job,
+)
+from zlib_ng import gzip_ng_threaded
+
+from ..core import DNO
+from ..resources.output_files import OutputFilesResource
+
+# Matches the data "as-is" with some minor optimisations, e.g. the
+# dictionary/categorical columns
+pyarrow_schema = pa.schema(
+    [
+        ("dataset_id", pa.string()),
+        ("dno_alias", pa.dictionary(pa.int32(), pa.string())),
+        ("secondary_substation_id", pa.string()),
+        ("secondary_substation_name", pa.dictionary(pa.int32(), pa.string())),
+        ("lv_feeder_id", pa.string()),
+        ("lv_feeder_name", pa.dictionary(pa.int32(), pa.string())),
+        ("aggregated_device_count_active", pa.float64()),
+        ("total_consumption_active_import", pa.float64()),
+        ("data_collection_log_timestamp", pa.timestamp("ms", tz="UTC")),
+        ("insert_time", pa.timestamp("ms", tz="UTC")),
+        ("last_modified_time", pa.timestamp("ms", tz="UTC")),
+    ]
+)
+pyarrow_csv_convert_options = pa_csv.ConvertOptions(
+    column_types=pyarrow_schema,
+    include_columns=[
+        "dataset_id",
+        "dno_alias",
+        "secondary_substation_id",
+        "secondary_substation_name",
+        "lv_feeder_id",
+        "lv_feeder_name",
+        "aggregated_device_count_active",
+        "total_consumption_active_import",
+        "data_collection_log_timestamp",
+        "insert_time",
+        "last_modified_time",
+    ],
+)
+
+
+@asset(
+    description="Monthly partitioned parquet files from SSEN's raw data",
+    partitions_def=MonthlyPartitionsDefinition(start_date="2024-02-01"),
+    deps=["ssen_lv_feeder_files"],
+)
+def ssen_lv_feeder_monthly_parquet(
+    context: AssetExecutionContext,
+    raw_files_resource: OutputFilesResource,
+    staging_files_resource: OutputFilesResource,
+) -> None:
+    partition_date = datetime.strptime(context.partition_key, "%Y-%m-%d")
+    year = partition_date.year
+    month = partition_date.month
+    monthly_file = f"{year}-{month:02d}.parquet"
+    daily_files = _ssen_files_for_month(year, month)
+    context.log.info(f"Producing {monthly_file} from {len(daily_files)} daily files")
+    with staging_files_resource.open(DNO.SSEN.value, monthly_file, mode="wb") as out:
+        parquet_writer = pq.ParquetWriter(out, pyarrow_schema)
+        for csv in daily_files:
+            try:
+                append_csv_to_parquet(context, raw_files_resource, parquet_writer, csv)
+            except FileNotFoundError:
+                context.log.info(
+                    f"Ignoring missing SSEN daily file {csv} when building monthly file {monthly_file}"
+                )
+        parquet_writer.close()
+
+
+def append_csv_to_parquet(context, raw_files_resource, parquet_writer, filename):
+    context.log.info(f"Processing {filename}")
+    with raw_files_resource.open(DNO.SSEN.value, filename, mode="rb") as gzipf:
+        with gzip_ng_threaded.open(gzipf, "rb", threads=pa.io_thread_count()) as f:
+            table = pa_csv.read_csv(f, convert_options=pyarrow_csv_convert_options)
+            parquet_writer.write_table(table)
+
+
+def _ssen_files_for_month(year: int, month: int):
+    """SSEN produces one file per day, so we need to get all the files for a month."""
+    last_day_of_month = calendar.monthrange(year, month)[1] + 1
+    files = []
+    for day in range(1, last_day_of_month):
+        files.append(f"{year}-{month:02d}-{day:02d}.csv.gz")
+    return files
+
+
+ssen_lv_feeder_monthly_parquet_job = define_asset_job(
+    "ssen_lv_feeder_monthly_parquet_job",
+    [ssen_lv_feeder_monthly_parquet],
+)

--- a/weave/definitions.py
+++ b/weave/definitions.py
@@ -3,7 +3,7 @@ import os
 from dagster import Definitions, load_assets_from_modules
 
 from .assets import dno_lv_feeder_files
-from .resources.raw_files import RawFilesResource
+from .resources.output_files import OutputFilesResource
 from .resources.ssen import LiveSSENAPIClient
 from .sensors import ssen_lv_feeder_files_sensor
 
@@ -15,7 +15,7 @@ FIXTURE_DIR = os.path.join(CURRENT_DIR, "..", "weave_tests", "fixtures")
 
 resources = {
     "dev_local": {
-        "raw_files_resource": RawFilesResource(
+        "raw_files_resource": OutputFilesResource(
             url=f"file://{os.path.join(DATA_DIR, "raw")}"
         ),
         "ssen_api_client": LiveSSENAPIClient(
@@ -23,13 +23,13 @@ resources = {
         ),
     },
     "dev_cloud": {
-        "raw_files_resource": RawFilesResource(url="s3://weave.energy-dev/data/raw"),
+        "raw_files_resource": OutputFilesResource(url="s3://weave.energy-dev/data/raw"),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),
     },
     "branch": {
-        "raw_files_resource": RawFilesResource(
+        "raw_files_resource": OutputFilesResource(
             url=f"s3://weave.energy-branches/{os.getenv("DAGSTER_CLOUD_GIT_BRANCH")}/data/raw"
         ),
         "ssen_api_client": LiveSSENAPIClient(
@@ -37,7 +37,7 @@ resources = {
         ),
     },
     "prod": {
-        "raw_files_resource": RawFilesResource(url="s3://weave.energy/data/raw"),
+        "raw_files_resource": OutputFilesResource(url="s3://weave.energy/data/raw"),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),

--- a/weave/definitions.py
+++ b/weave/definitions.py
@@ -2,12 +2,14 @@ import os
 
 from dagster import Definitions, load_assets_from_modules
 
-from .assets import dno_lv_feeder_files
+from .assets import dno_lv_feeder_files, dno_lv_feeder_monthly_parquet
 from .resources.output_files import OutputFilesResource
 from .resources.ssen import LiveSSENAPIClient
-from .sensors import ssen_lv_feeder_files_sensor
+from .sensors import ssen_lv_feeder_files_sensor, ssen_lv_feeder_monthly_parquet_sensor
 
-all_assets = load_assets_from_modules([dno_lv_feeder_files])
+all_assets = load_assets_from_modules(
+    [dno_lv_feeder_files, dno_lv_feeder_monthly_parquet]
+)
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
 DATA_DIR = os.path.join(CURRENT_DIR, "..", "data")
@@ -18,12 +20,18 @@ resources = {
         "raw_files_resource": OutputFilesResource(
             url=f"file://{os.path.join(DATA_DIR, "raw")}"
         ),
+        "staging_files_resource": OutputFilesResource(
+            url=f"file://{os.path.join(DATA_DIR, "staging")}"
+        ),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),
     },
     "dev_cloud": {
         "raw_files_resource": OutputFilesResource(url="s3://weave.energy-dev/data/raw"),
+        "staging_files_resource": OutputFilesResource(
+            url="s3://weave.energy-dev/data/staging"
+        ),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),
@@ -32,12 +40,18 @@ resources = {
         "raw_files_resource": OutputFilesResource(
             url=f"s3://weave.energy-branches/{os.getenv("DAGSTER_CLOUD_GIT_BRANCH")}/data/raw"
         ),
+        "staging_files_resource": OutputFilesResource(
+            url=f"s3://weave.energy-branches/{os.getenv("DAGSTER_CLOUD_GIT_BRANCH")}/data/staging"
+        ),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),
     },
     "prod": {
         "raw_files_resource": OutputFilesResource(url="s3://weave.energy/data/raw"),
+        "staging_files_resource": OutputFilesResource(
+            url="s3://weave.energy/data/staging"
+        ),
         "ssen_api_client": LiveSSENAPIClient(
             available_files_url="https://ssen-smart-meter-prod.datopian.workers.dev/LV_FEEDER_USAGE/"
         ),
@@ -74,6 +88,6 @@ def deployment_name():
 
 defs = Definitions(
     assets=all_assets,
-    sensors=[ssen_lv_feeder_files_sensor],
+    sensors=[ssen_lv_feeder_files_sensor, ssen_lv_feeder_monthly_parquet_sensor],
     resources=resources[deployment_name()],
 )

--- a/weave/resources/output_files.py
+++ b/weave/resources/output_files.py
@@ -2,7 +2,7 @@ import fsspec
 from dagster import ConfigurableResource
 
 
-class RawFilesResource(ConfigurableResource):
+class OutputFilesResource(ConfigurableResource):
     """Wrap fsspec to be aware of our naming conventions for raw files"""
 
     url: str

--- a/weave/resources/ssen.py
+++ b/weave/resources/ssen.py
@@ -30,6 +30,13 @@ class SSENAPIClient(ConfigurableResource, ABC):
     def filename_for_url(cls, url: str) -> str:
         return url.split("/")[-1]
 
+    @classmethod
+    def month_partition_from_url(cls, url: str) -> str:
+        filename = cls.filename_for_url(url)
+        bare_filename = filename.rstrip(".csv")
+        year, month, day = bare_filename.split("-")
+        return f"{year}-{month}-01"
+
     def _map_available_files(self, api_response: dict) -> list[AvailableFile]:
         available = [self._map_available_file(o) for o in api_response["objects"]]
         return sorted(available, key=lambda f: f.filename)

--- a/weave/resources/ssen.py
+++ b/weave/resources/ssen.py
@@ -26,7 +26,8 @@ class SSENAPIClient(ConfigurableResource, ABC):
     ):
         pass
 
-    def filename_for_url(self, url: str) -> str:
+    @classmethod
+    def filename_for_url(cls, url: str) -> str:
         return url.split("/")[-1]
 
     def _map_available_files(self, api_response: dict) -> list[AvailableFile]:

--- a/weave/sensors.py
+++ b/weave/sensors.py
@@ -1,4 +1,6 @@
 from dagster import (
+    DagsterEventType,
+    EventRecordsFilter,
     RunRequest,
     SensorEvaluationContext,
     SensorResult,
@@ -7,9 +9,11 @@ from dagster import (
 )
 
 from .assets.dno_lv_feeder_files import (
+    ssen_lv_feeder_files,
     ssen_lv_feeder_files_job,
     ssen_lv_feeder_files_partitions_def,
 )
+from .assets.dno_lv_feeder_monthly_parquet import ssen_lv_feeder_monthly_parquet_job
 from .resources.ssen import SSENAPIClient
 
 
@@ -32,6 +36,55 @@ def ssen_lv_feeder_files_sensor(
                 ssen_lv_feeder_files_partitions_def.build_add_request(new)
             ],
             cursor=latest_filename,
+        )
+    else:
+        return SkipReason(skip_message="No new files found")
+
+
+@sensor(job=ssen_lv_feeder_monthly_parquet_job)
+def ssen_lv_feeder_monthly_parquet_sensor(context: SensorEvaluationContext):
+    """Sensor for monthly partitioned parquet files from SSEN's raw data.
+
+    This should be possible with Dagster natively really, but there's no way to map the
+    relationship from dynamically partitioned assets to monthly partitioned ones. You
+    can't supply your own PartitionMapping class."""
+
+    # Turn the string cursor into one we can query with. Figured out from reading the
+    # source code: https://docs.dagster.io/_modules/dagster/_core/event_api
+    cursor = None
+    if context.cursor:
+        cursor = int(context.cursor)
+        context.log.info(f"Parsed cursor: {cursor}")
+    # Find new materialisations of the raw files
+    new_materialisations = context.instance.get_event_records(
+        EventRecordsFilter(
+            event_type=DagsterEventType.ASSET_MATERIALIZATION,
+            asset_key=ssen_lv_feeder_files.key,
+            after_cursor=cursor,
+        ),
+        limit=None,
+        ascending=True,
+    )
+
+    context.log.info(
+        f"Found {len(new_materialisations)} new materialisation events for raw SSEN lv feeder files since cursor"
+    )
+    # Map them to the monthly partitions we need to create or update
+    partitions = sorted(
+        {
+            SSENAPIClient.month_partition_from_url(m.partition_key)
+            for m in new_materialisations
+        }
+    )
+
+    context.log.info(f"Mapped events to {partitions} monthly partitions")
+
+    if len(partitions) > 0:
+        latest_materialisation = new_materialisations[-1]
+        context.log.info(f"New cursor is {cursor}")
+        return SensorResult(
+            run_requests=[RunRequest(partition_key=p) for p in partitions],
+            cursor=str(latest_materialisation.storage_id),
         )
     else:
         return SkipReason(skip_message="No new files found")

--- a/weave/sensors.py
+++ b/weave/sensors.py
@@ -41,7 +41,7 @@ def ssen_lv_feeder_files_sensor(
         return SkipReason(skip_message="No new files found")
 
 
-@sensor(job=ssen_lv_feeder_monthly_parquet_job)
+@sensor(job=ssen_lv_feeder_monthly_parquet_job, minimum_interval_seconds=60 * 5)
 def ssen_lv_feeder_monthly_parquet_sensor(context: SensorEvaluationContext):
     """Sensor for monthly partitioned parquet files from SSEN's raw data.
 

--- a/weave_tests/test_assets.py
+++ b/weave_tests/test_assets.py
@@ -5,7 +5,8 @@ import pytest
 from dagster import build_asset_context
 
 from weave.assets.dno_lv_feeder_files import ssen_lv_feeder_files
-from weave.resources.raw_files import RawFilesResource
+from weave.assets.dno_lv_feeder_monthly_parquet import ssen_lv_feeder_monthly_parquet
+from weave.resources.output_files import OutputFilesResource
 from weave.resources.ssen import TestSSENAPIClient
 
 FIXTURE_DIR = os.path.join(
@@ -28,7 +29,7 @@ def test_ssen_lv_feeder_files(tmp_path, ssen_api_client):
     context = build_asset_context(
         partition_key="https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-12.csv"
     )
-    raw_files_resource = RawFilesResource(url=tmp_path.as_uri())
+    raw_files_resource = OutputFilesResource(url=tmp_path.as_uri())
     ssen_lv_feeder_files(context, raw_files_resource, ssen_api_client)
 
     df = pd.read_csv((output_dir / "2024-02-12.csv.gz").as_posix())

--- a/weave_tests/test_assets.py
+++ b/weave_tests/test_assets.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 import pytest
 from dagster import build_asset_context
+from zlib_ng import zlib_ng
 
 from weave.assets.dno_lv_feeder_files import ssen_lv_feeder_files
 from weave.assets.dno_lv_feeder_monthly_parquet import ssen_lv_feeder_monthly_parquet
@@ -34,3 +35,31 @@ def test_ssen_lv_feeder_files(tmp_path, ssen_api_client):
 
     df = pd.read_csv((output_dir / "2024-02-12.csv.gz").as_posix())
     assert len(df) == 10
+
+
+def create_daily_files(year, month, start, end, dir):
+    input_file = os.path.join(FIXTURE_DIR, "ssen_2024-02-12_head.csv")
+    for day in range(start, end):
+        filename = dir / f"{year}-{month:02d}-{day:02d}.csv.gz"
+        with open(filename.as_posix(), "wb") as output_file:
+            with open(input_file, "rb") as f:
+                output_file.write(
+                    zlib_ng.compress(f.read(), level=1, wbits=zlib_ng.MAX_WBITS | 16)
+                )
+
+
+def test_ssen_lv_feeder_monthly_parquet(tmp_path):
+    output_dir = tmp_path / "staging" / "ssen"
+    output_dir.mkdir(parents=True)
+    input_dir = tmp_path / "raw" / "ssen"
+    input_dir.mkdir(parents=True)
+    create_daily_files(2024, 2, 1, 30, input_dir)  # 2024 was a leap year
+    context = build_asset_context(partition_key="2024-02-01")
+    staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
+    raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+    ssen_lv_feeder_monthly_parquet(context, raw_files_resource, staging_files_resource)
+
+    df = pd.read_parquet((output_dir / "2024-02.parquet").as_posix(), engine="pyarrow")
+    assert len(df) == 10 * 29
+    # Testing categoricals correctly survive pyarrow -> pandas roundtrip
+    assert isinstance(df.dtypes["dno_alias"], pd.CategoricalDtype)

--- a/weave_tests/test_sensors.py
+++ b/weave_tests/test_sensors.py
@@ -1,10 +1,23 @@
 import os
 
 import pytest
-from dagster import DagsterInstance, SkipReason, build_sensor_context
+from dagster import (
+    DagsterInstance,
+    SkipReason,
+    build_sensor_context,
+    materialize_to_memory,
+)
 
+from weave.assets.dno_lv_feeder_files import (
+    ssen_lv_feeder_files,
+    ssen_lv_feeder_files_partitions_def,
+)
+from weave.resources.output_files import OutputFilesResource
 from weave.resources.ssen import TestSSENAPIClient
-from weave.sensors import ssen_lv_feeder_files_sensor
+from weave.sensors import (
+    ssen_lv_feeder_files_sensor,
+    ssen_lv_feeder_monthly_parquet_sensor,
+)
 
 FIXTURE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -25,8 +38,16 @@ def context(instance):
 @pytest.fixture
 def api_client():
     return TestSSENAPIClient(
-        available_files_url=os.path.join(FIXTURE_DIR, "ssen_files.json")
+        available_files_url=os.path.join(FIXTURE_DIR, "ssen_files.json"),
+        file_to_download=os.path.join(FIXTURE_DIR, "ssen_2024-02-12_head.csv"),
     )
+
+
+@pytest.fixture
+def raw_files_resource(tmp_path):
+    output_dir = tmp_path / "raw" / "ssen"
+    output_dir.mkdir(parents=True)
+    return OutputFilesResource(url=tmp_path.as_uri())
 
 
 class TestSSENLVFeederFilesSensor:
@@ -69,3 +90,88 @@ class TestSSENLVFeederFilesSensor:
         )
         result = ssen_lv_feeder_files_sensor(context, ssen_api_client=api_client)
         assert isinstance(result, SkipReason)
+
+
+class TestSSENLVFeederMonthlyParquetSensor:
+    def test_clean_slate(self, context, api_client):
+        result = ssen_lv_feeder_monthly_parquet_sensor(context)
+        assert isinstance(result, SkipReason)
+
+    def _materialize_raw_file(self, raw_file, instance, api_client, raw_files_resource):
+        materialize_to_memory(
+            [ssen_lv_feeder_files],
+            instance=instance,
+            partition_key=raw_file,
+            resources={
+                "ssen_api_client": api_client,
+                "raw_files_resource": raw_files_resource,
+            },
+        )
+
+    def test_with_cursor(self, instance, context, api_client, raw_files_resource):
+        instance.add_dynamic_partitions(
+            ssen_lv_feeder_files_partitions_def.name,
+            [
+                "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-12.csv",
+                "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-13.csv",
+                "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-03-01.csv",
+            ],
+        )
+        self._materialize_raw_file(
+            "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-12.csv",
+            instance,
+            api_client,
+            raw_files_resource,
+        )
+        self._materialize_raw_file(
+            "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-13.csv",
+            instance,
+            api_client,
+            raw_files_resource,
+        )
+        self._materialize_raw_file(
+            "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-03-01.csv",
+            instance,
+            api_client,
+            raw_files_resource,
+        )
+        result = ssen_lv_feeder_monthly_parquet_sensor(context)
+        assert len(result.run_requests) == 2
+        # Multiple new partitions in a month should be deduped
+        assert result.run_requests[0].partition_key == "2024-02-01"
+        assert result.run_requests[1].partition_key == "2024-03-01"
+
+        # When we re-materialise a daily partition, we should get a run request to
+        # rebuild the relevant monthly parquet file
+        self._materialize_raw_file(
+            "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-02-13.csv",
+            instance,
+            api_client,
+            raw_files_resource,
+        )
+
+        new_context = build_sensor_context(instance=instance, cursor=result.cursor)
+        result = ssen_lv_feeder_monthly_parquet_sensor(new_context)
+        assert len(result.run_requests) == 1
+        assert result.run_requests[0].partition_key == "2024-02-01"
+
+        # When we add a new file for a new month, we should get a run request to
+        # rebuild the relevant monthly parquet file
+
+        instance.add_dynamic_partitions(
+            ssen_lv_feeder_files_partitions_def.name,
+            [
+                "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2023-12-10.csv"
+            ],
+        )
+        self._materialize_raw_file(
+            "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2023-12-10.csv",
+            instance,
+            api_client,
+            raw_files_resource,
+        )
+
+        new_context = build_sensor_context(instance=instance, cursor=result.cursor)
+        result = ssen_lv_feeder_monthly_parquet_sensor(new_context)
+        assert len(result.run_requests) == 1
+        assert result.run_requests[0].partition_key == "2023-12-01"


### PR DESCRIPTION
The next step in our data pipeline after grabbing the raw data - starting to shape it how we want.

A few decisions I've made here (all trialling for now):

- Use parquet files internally to speed things up, save space and bandwidth
- Partition the data monthly, as the basis for future output partitioning
- Be quite explicit about what we're expecting in the raw data CSVs by hard-coding the schema
- Also be quite frugal in the sense of limiting the columns we transfer and using dictionary encoding on some fields where it makes sense
- However, not fundamentally changing the data at this point beyond aggregating (e.g. not down-casting consumption to integers from floats despite the space it's wasting)
- Using pyarrow directly rather than pandas - after some benchmarking it's at least 10x faster