### PR TITLE
Add jupyter notebook for SSEN's July dip

### DIFF
--- a/experiments/ssen-july-dip.ipynb
+++ b/experiments/ssen-july-dip.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exploring the July dip in SSEN data\n",
+    "\n",
+    "We've been working on getting our hands on more smart meter data than just February 2024, so that we can look for seasonal trends and make other analyses over a longer time period. When we did so, we noticed a weird \"dip\" in consumption around mid July. \n",
+    "\n",
+    "At the time we were only look at a small random sample of feeders, so first we checked if there was a bug in our data pipeline. Maybe we'd missed some files to download? It seems not - the original raw files on [the data portal](https://data.ssen.co.uk/@ssen-distribution/ssen_smart_meter_prod_lv_feeder/r/1cce1fb4-d7f4-4309-b9e3-943bd4d18618) are noticeably smaller for the period roughly between 10/07 -> 25/07.\n",
+    "\n",
+    "To get to the bottom of it, we loaded two days into Pandas dataframes and compared them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "sixteenth = pd.read_csv(\"https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-07-16.csv\", storage_options={'User-Agent': 'Mozilla/5.0'})\n",
+    "thirtyfirst = pd.read_csv(\"https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_USAGE/2024-07-31.csv\", storage_options={'User-Agent': 'Mozilla/5.0'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Take a general look at the data, note that 16/07 is noticeably smaller (394MB vs 539MB)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 3043011 entries, 0 to 3043010\n",
+      "Data columns (total 17 columns):\n",
+      " #   Column                               Non-Null Count    Dtype  \n",
+      "---  ------                               --------------    -----  \n",
+      " 0   dataset_id                           3043011 non-null  int64  \n",
+      " 1   dno_name                             3043011 non-null  object \n",
+      " 2   dno_alias                            3043011 non-null  object \n",
+      " 3   secondary_substation_id              3043011 non-null  int64  \n",
+      " 4   secondary_substation_name            2983468 non-null  object \n",
+      " 5   lv_feeder_id                         3043011 non-null  int64  \n",
+      " 6   lv_feeder_name                       791008 non-null   object \n",
+      " 7   substation_geo_location              0 non-null        float64\n",
+      " 8   aggregated_device_count_active       2720582 non-null  float64\n",
+      " 9   primary_consumption_active_import    2720582 non-null  float64\n",
+      " 10  secondary_consumption_active_import  0 non-null        float64\n",
+      " 11  total_consumption_active_import      2720582 non-null  float64\n",
+      " 12  aggregated_device_count_reactive     2728109 non-null  float64\n",
+      " 13  total_consumption_reactive_import    2728109 non-null  float64\n",
+      " 14  data_collection_log_timestamp        3043011 non-null  object \n",
+      " 15  insert_time                          3043011 non-null  object \n",
+      " 16  last_modified_time                   3043011 non-null  object \n",
+      "dtypes: float64(7), int64(3), object(7)\n",
+      "memory usage: 394.7+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "sixteenth.info(show_counts=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 4157612 entries, 0 to 4157611\n",
+      "Data columns (total 17 columns):\n",
+      " #   Column                               Non-Null Count    Dtype  \n",
+      "---  ------                               --------------    -----  \n",
+      " 0   dataset_id                           4157612 non-null  int64  \n",
+      " 1   dno_name                             4157612 non-null  object \n",
+      " 2   dno_alias                            4157612 non-null  object \n",
+      " 3   secondary_substation_id              4157612 non-null  int64  \n",
+      " 4   secondary_substation_name            4075437 non-null  object \n",
+      " 5   lv_feeder_id                         4157612 non-null  int64  \n",
+      " 6   lv_feeder_name                       1049872 non-null  object \n",
+      " 7   substation_geo_location              0 non-null        float64\n",
+      " 8   aggregated_device_count_active       4155444 non-null  float64\n",
+      " 9   primary_consumption_active_import    4155444 non-null  float64\n",
+      " 10  secondary_consumption_active_import  0 non-null        float64\n",
+      " 11  total_consumption_active_import      4155444 non-null  float64\n",
+      " 12  aggregated_device_count_reactive     4155890 non-null  float64\n",
+      " 13  total_consumption_reactive_import    4155890 non-null  float64\n",
+      " 14  data_collection_log_timestamp        4157612 non-null  object \n",
+      " 15  insert_time                          4157612 non-null  object \n",
+      " 16  last_modified_time                   4157612 non-null  object \n",
+      "dtypes: float64(7), int64(3), object(7)\n",
+      "memory usage: 539.2+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "thirtyfirst.info(show_counts=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try to work out why that is, are we missing some half-hours of the day?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "48"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirtyfirst[\"data_collection_log_timestamp\"].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "48"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sixteenth[\"data_collection_log_timestamp\"].nunique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Doesn't look like it, maybe we are missing values for some feeders?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "63420"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sixteenth[\"dataset_id\"].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "86637"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thirtyfirst[\"dataset_id\"].nunique()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "We're missing values for quite a lot of feeders (23,000) in the middle of July, where have they gone?"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Exploring why SSEN's data has a dip in the middle of July - we're missing values for quite a lot of feeders (23,000) in the middle of July, where have they gone?