### PR TITLE
Fix backfill partition check

### DIFF
--- a/weave/assets/dno_lv_feeder_monthly_parquet.py
+++ b/weave/assets/dno_lv_feeder_monthly_parquet.py
@@ -6,6 +6,8 @@ import pyarrow.compute as pc
 import pyarrow.csv as pa_csv
 import pyarrow.parquet as pq
 from dagster import (
+    AllPartitionMapping,
+    AssetDep,
     AssetExecutionContext,
     AssetSelection,
     AutomationCondition,
@@ -62,7 +64,10 @@ pyarrow_csv_convert_options = pa_csv.ConvertOptions(
     substation locations added""",
     partitions_def=MonthlyPartitionsDefinition(start_date="2024-02-01", end_offset=1),
     deps=[
-        "ssen_lv_feeder_files",
+        # Each partition is not really dependent on all of the partitions of the raw
+        # files, but we don't have a way to express that in Dagster yet. This stops it
+        # breaking when it tries to check there are valid partitions.
+        AssetDep("ssen_lv_feeder_files", partition_mapping=AllPartitionMapping()),
         "ssen_substation_location_lookup_feeder_postcodes",
         "ssen_substation_location_lookup_transformer_load_model",
     ],

--- a/weave/assets/dno_lv_feeder_monthly_parquet.py
+++ b/weave/assets/dno_lv_feeder_monthly_parquet.py
@@ -62,10 +62,7 @@ pyarrow_csv_convert_options = pa_csv.ConvertOptions(
     substation locations added""",
     partitions_def=MonthlyPartitionsDefinition(start_date="2024-02-01", end_offset=1),
     deps=[
-        # "ssen_lv_feeder_files", - Can't tell dagster about this dependency or it
-        # will try to check it has matching partitions, which it doesn't because it's
-        # dynamic. This breaks launching backfills, either manually or automatically
-        # through the automation_condition.
+        "ssen_lv_feeder_files",
         "ssen_substation_location_lookup_feeder_postcodes",
         "ssen_substation_location_lookup_transformer_load_model",
     ],


### PR DESCRIPTION
Rather than removing the dependency completely, as I did in https://github.com/centre-for-ai-and-climate/weave/pull/6, this
tells Dagster a slightly less untrue thing - that each month depends on
the whole set of raw data partitions. This isn't right either, but it
allows Dagster to check that things are somewhat "valid" and thus allows
us to run backfills, both manually and automatically.

It seems like mapping dynamic partitions is a bit of a pain point in
Dagster, that they don't have a great solution for (https://github.com/dagster-io/dagster/issues/13139)
so we're probably going against the grain here.

Note: in this case I could kinda cheat by creating a
StaticPartitionMapping, because each filename is a day, or I could even
maybe represent the raw data as a DailyPartitionsDefinition, but the
fact that the latest data is released ad-hoc would spoil it. That
solution also wouldn't work for NGED, where the data is released in
random part chunks, so I haven't done it here. It might be worth seeing
if we could better represent that aspect of the data in the future,
though.