### PR TITLE
Make SSEN LV Feeder downloads more robust to bad files

### DIFF
--- a/weave/assets/dno_lv_feeder_files.py
+++ b/weave/assets/dno_lv_feeder_files.py
@@ -1,11 +1,14 @@
+import pyarrow as pa
 from dagster import (
     AssetExecutionContext,
     Backoff,
     DynamicPartitionsDefinition,
+    MaterializeResult,
     RetryPolicy,
     asset,
     define_asset_job,
 )
+from dagster_pandas.data_frame import create_table_schema_metadata_from_dataframe
 
 from ..core import DNO
 from ..resources.output_files import OutputFilesResource
@@ -25,11 +28,30 @@ def ssen_lv_feeder_files(
     context: AssetExecutionContext,
     raw_files_resource: OutputFilesResource,
     ssen_api_client: SSENAPIClient,
-) -> None:
+) -> MaterializeResult:
     url = context.partition_key
     filename = f"{SSENAPIClient.filename_for_url(url)}.gz"
+    metadata = {}
     with raw_files_resource.open(DNO.SSEN.value, filename, mode="wb") as f:
         ssen_api_client.download_file(context, url, f)
+    with raw_files_resource.open(DNO.SSEN.value, filename, mode="rb") as f:
+        try:
+            table = ssen_api_client.lv_feeder_file_pyarrow_table(f)
+            df = table.to_pandas()
+            metadata["dagster/uri"] = raw_files_resource.path(DNO.SSEN.value, filename)
+            metadata["dagster/row_count"] = len(df)
+            metadata["dagster/column_schema"] = (
+                create_table_schema_metadata_from_dataframe(df)
+            )
+            metadata["weave/source"] = url
+            metadata["weave/nunique_feeders"] = df["dataset_id"].nunique()
+        except pa.lib.ArrowInvalid as e:
+            context.log.error(f"Failed to read {url} into a PyArrow table: {e}")
+            context.log.info(f"Attempting to delete {filename}")
+            raw_files_resource.delete(DNO.SSEN.value, filename)
+            raise
+
+    return MaterializeResult(metadata=metadata)
 
 
 ssen_lv_feeder_files_job = define_asset_job(

--- a/weave/resources/output_files.py
+++ b/weave/resources/output_files.py
@@ -12,3 +12,7 @@ class OutputFilesResource(ConfigurableResource):
 
     def path(self, dno, filename):
         return f"{self.url}/{dno}/{filename}"
+
+    def delete(self, dno, filename):
+        file = self.open(dno, filename)
+        return file.fs.delete(file.path)

--- a/weave/resources/ssen.py
+++ b/weave/resources/ssen.py
@@ -4,13 +4,16 @@ import zipfile
 import zlib
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from typing import ClassVar
 
 import humanize
 import pandas as pd
+import pyarrow as pa
+import pyarrow.csv as pa_csv
 import requests
 from dagster import AssetExecutionContext, ConfigurableResource
 from fsspec.core import OpenFile
-from zlib_ng import zlib_ng
+from zlib_ng import gzip_ng_threaded, zlib_ng
 
 from ..core import AvailableFile
 
@@ -23,6 +26,26 @@ class SSENAPIClient(ConfigurableResource, ABC):
     )
     postcode_mapping_url: str = "https://ssen-smart-meter-prod.portaljs.com/LV_FEEDER_LOOKUP/LV_FEEDER_LOOKUP.csv"
     transformer_load_model_url: str = "https://data-api.ssen.co.uk/dataset/d1c4009b-4386-4208-a14f-cc09aeeb4777/resource/53b2b871-4c28-4ba9-85d4-c9ba6452aa15/download/onedrive_1_01-08-2024.zip"
+    # Matches the data "as-is". I wanted to add some space-saving optimizations
+    # like dictionaries for the name columns, but it doesn't work with joining for some
+    # reason.
+    # See https://github.com/pydantic/pydantic/issues/1927
+    lv_feeder_pyarrow_schema: ClassVar = pa.schema(
+        [
+            ("dataset_id", pa.string()),
+            ("dno_alias", pa.string()),
+            ("secondary_substation_id", pa.string()),
+            ("secondary_substation_name", pa.string()),
+            ("lv_feeder_id", pa.string()),
+            ("lv_feeder_name", pa.string()),
+            ("substation_geo_location", pa.string()),
+            ("aggregated_device_count_active", pa.float64()),
+            ("total_consumption_active_import", pa.float64()),
+            ("data_collection_log_timestamp", pa.timestamp("ms", tz="UTC")),
+            ("insert_time", pa.timestamp("ms", tz="UTC")),
+            ("last_modified_time", pa.timestamp("ms", tz="UTC")),
+        ]
+    )
 
     @abstractmethod
     def get_available_files(self) -> list[AvailableFile]:
@@ -79,6 +102,28 @@ class SSENAPIClient(ConfigurableResource, ABC):
                 with zipfile.ZipFile(io.BytesIO(z_inner.read())) as z_nested:
                     with z_nested.open("SEPD_transformers_open_data_with_nrn.csv") as f:
                         return pd.read_csv(f, usecols=cols, dtype=dtypes)
+
+    def lv_feeder_file_pyarrow_table(self, input_file: OpenFile):
+        """Read an LV Feeder CSV file into a PyArrow Table."""
+        pyarrow_csv_convert_options = pa_csv.ConvertOptions(
+            column_types=self.lv_feeder_pyarrow_schema,
+            include_columns=[
+                "dataset_id",
+                "dno_alias",
+                "secondary_substation_id",
+                "secondary_substation_name",
+                "lv_feeder_id",
+                "lv_feeder_name",
+                "substation_geo_location",
+                "aggregated_device_count_active",
+                "total_consumption_active_import",
+                "data_collection_log_timestamp",
+                "insert_time",
+                "last_modified_time",
+            ],
+        )
+        with gzip_ng_threaded.open(input_file, "rb", threads=pa.io_thread_count()) as f:
+            return pa_csv.read_csv(f, convert_options=pyarrow_csv_convert_options)
 
 
 class LiveSSENAPIClient(SSENAPIClient):

--- a/weave_tests/assets/test_dno_lv_feeder_monthly_parquet.py
+++ b/weave_tests/assets/test_dno_lv_feeder_monthly_parquet.py
@@ -6,6 +6,7 @@ from zlib_ng import zlib_ng
 
 from weave.assets.dno_lv_feeder_monthly_parquet import ssen_lv_feeder_monthly_parquet
 from weave.resources.output_files import OutputFilesResource
+from weave.resources.ssen import StubSSENAPICLient
 
 FIXTURE_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
@@ -63,8 +64,11 @@ def test_ssen_lv_feeder_monthly_parquet(tmp_path):
     context = build_asset_context(partition_key="2024-02-01")
     staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
     raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+    ssen_api_client = StubSSENAPICLient()
 
-    ssen_lv_feeder_monthly_parquet(context, raw_files_resource, staging_files_resource)
+    ssen_lv_feeder_monthly_parquet(
+        context, raw_files_resource, staging_files_resource, ssen_api_client
+    )
 
     df = pd.read_parquet(output_dir / "2024-02.parquet", engine="pyarrow")
     assert len(df) == 6 * 29  # 6 rows in the fixture * 29 days


### PR DESCRIPTION
We've just had our first experience of a bad file from the SSEN API. They have published a 0B file in place of the data for 11-18-2024.

With our existing pipeline, this breaks the whole of November's data, because we download it without any checks, and then the monthly partition falls over when it tries to parse it.

To fix this, I've added a check to the raw file step which tries to parse the data into a PyArrow table and if it fails, deletes the file. This now raises an error at the earlier stage, so we see a more useful failure upstream, but it also means we don't download a bad raw file, so we can continue to produce the monthly data without interruption.

Perhaps in the future we'll want to introduce a quarantine step or similar, but this is okay for now.

I took this opportunity to refactor the PyArrow table creation into the SSEN API client, so it lives more closely to all the other code that knows about us GZipping the files.

I also took this opportunity to add some metadata to the materializations, because it was missing from my first pass at these files.