### PR TITLE
Combined parquet output

### DIFF
--- a/weave/assets/dno_lv_feeder_combined_geoparquet.py
+++ b/weave/assets/dno_lv_feeder_combined_geoparquet.py
@@ -1,0 +1,31 @@
+from dagster import (
+    AllPartitionMapping,
+    AssetDep,
+    AssetExecutionContext,
+    AutomationCondition,
+    MaterializeResult,
+    asset,
+)
+
+from ..resources.output_files import OutputFilesResource
+
+
+@asset(
+    description="""Combined LV Feeder GeoParquet from all DNOs.
+
+    An ever-growing monthly-partitioned geoparquet file containing all the low-voltage
+    feeder data we have.""",
+    deps=[
+        AssetDep(
+            "ssen_lv_feeder_monthly_parquet", partition_mapping=AllPartitionMapping()
+        )
+    ],
+    automation_condition=AutomationCondition.on_missing(),
+)
+def lv_feeder_combined_geoparquet(
+    context: AssetExecutionContext,
+    staging_files_resource: OutputFilesResource,
+    output_files_resource: OutputFilesResource,
+) -> MaterializeResult:
+    metadata = {}
+    return MaterializeResult(metadata=metadata)

--- a/weave/assets/dno_lv_feeder_combined_geoparquet.py
+++ b/weave/assets/dno_lv_feeder_combined_geoparquet.py
@@ -1,12 +1,19 @@
+from datetime import datetime
+
+import geopandas as gpd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
 from dagster import (
-    AllPartitionMapping,
-    AssetDep,
     AssetExecutionContext,
     AutomationCondition,
     MaterializeResult,
+    MonthlyPartitionsDefinition,
     asset,
 )
+from geopandas.io.arrow import _geopandas_to_arrow
 
+from ..core import DNO, lv_feeder_geoparquet_schema
 from ..resources.output_files import OutputFilesResource
 
 
@@ -15,11 +22,8 @@ from ..resources.output_files import OutputFilesResource
 
     An ever-growing monthly-partitioned geoparquet file containing all the low-voltage
     feeder data we have.""",
-    deps=[
-        AssetDep(
-            "ssen_lv_feeder_monthly_parquet", partition_mapping=AllPartitionMapping()
-        )
-    ],
+    partitions_def=MonthlyPartitionsDefinition(start_date="2024-02-01", end_offset=1),
+    deps=["ssen_lv_feeder_monthly_parquet"],
     automation_condition=AutomationCondition.on_missing(),
 )
 def lv_feeder_combined_geoparquet(
@@ -28,4 +32,154 @@ def lv_feeder_combined_geoparquet(
     output_files_resource: OutputFilesResource,
 ) -> MaterializeResult:
     metadata = {}
+    metadata["dagster/row_count"] = 0
+    metadata["weave/nunique_feeders"] = 0
+    metadata["weave/nunique_substations"] = 0
+
+    partition_date = datetime.strptime(context.partition_key, "%Y-%m-%d")
+    year = partition_date.year
+    month = partition_date.month
+    monthly_file = f"{year}-{month:02d}.parquet"
+
+    with output_files_resource.open("smart-meter", monthly_file, mode="wb") as out:
+        sorting_columns = [
+            pq.SortingColumn(4),
+            pq.SortingColumn(1),
+            pq.SortingColumn(6),
+            pq.SortingColumn(7),
+        ]
+        parquet_writer = pq.ParquetWriter(
+            out,
+            schema=lv_feeder_geoparquet_schema,
+            compression="zstd",
+            compression_level=22,
+            coerce_timestamps="ms",
+            allow_truncated_timestamps=True,
+            sorting_columns=sorting_columns,
+            store_decimal_as_integer=True,
+        )
+        metadata["dagster/uri"] = output_files_resource.path(
+            "smart-meter", monthly_file
+        )
+        # Eventually this should loop over several DNOs and do different things for each
+        with staging_files_resource.open(
+            DNO.SSEN.value, monthly_file, mode="rb"
+        ) as in_file:
+            parquet_file = pq.ParquetFile(in_file)
+            total_rows = parquet_file.metadata.num_rows
+            processed_rows = 0
+            context.log.info(f"Processing file: {in_file}, total_rows: {total_rows}")
+            for batch in parquet_file.iter_batches(
+                batch_size=1024 * 1024,
+                columns=[
+                    "dataset_id",
+                    "dno_alias",
+                    "aggregated_device_count_active",
+                    "total_consumption_active_import",
+                    "data_collection_log_timestamp",
+                    "substation_geo_location",
+                ],
+            ):
+                table = _ssen_to_combined_geoparquet(batch, context)
+                table = table.sort_by(
+                    [
+                        ("data_collection_log_timestamp", "ascending"),
+                        ("dno_alias", "ascending"),
+                        ("secondary_substation_unique_id", "ascending"),
+                        ("lv_feeder_unique_id", "ascending"),
+                    ]
+                )
+                parquet_writer.write_table(table)
+                metadata["dagster/row_count"] += table.num_rows
+                metadata["weave/nunique_feeders"] += pc.count_distinct(
+                    table.column("lv_feeder_unique_id")
+                ).as_py()
+                metadata["weave/nunique_substations"] += pc.count_distinct(
+                    table.column("secondary_substation_unique_id")
+                ).as_py()
+
+                processed_rows += table.num_rows
+                percentage_processed = processed_rows / total_rows * 100
+                context.log.info(
+                    f"Processed {processed_rows} rows ({percentage_processed}% of total)"
+                )
+        parquet_writer.close()
+
     return MaterializeResult(metadata=metadata)
+
+
+def _ssen_to_combined_geoparquet(
+    batch: pa.RecordBatch, context: AssetExecutionContext
+) -> pa.Table:
+    # Clear any existing metadata
+    batch = batch.replace_schema_metadata(None)
+
+    # Add geoarrow-encoded geometry columns.
+    # I tried adopting the code from geopandas directly, so that we could stick to
+    # pyarrow throughout, but it is dense and hard to adapt. I got stuck on the fact
+    # that we have some null locations, which I think geopandas works around through
+    # the use of masks, but it was a bit over my head.
+    # This is one to come back to, I don't like using _geopandas_to_arrow.
+
+    # This is also unreliable in terms of data type conversions, so we do it first and
+    # then apply our specific casts after to make sure things stay as we want them
+    df = batch.to_pandas(self_destruct=True)
+    df[["lat", "lng"]] = df["substation_geo_location"].str.split(",", n=1, expand=True)
+    gdf = gpd.GeoDataFrame(
+        df, geometry=gpd.points_from_xy(df["lng"], df["lat"], crs="EPSG:4326")
+    )
+    del df
+    # Public to_arrow method does not include the schema_version or bbox options, nor
+    # does it do all the fancy metadata for parquet output.
+    table = _geopandas_to_arrow(
+        gdf,
+        index=False,
+        geometry_encoding="geoarrow",
+        schema_version="1.1.0",
+        write_covering_bbox=True,
+    )
+    del gdf
+
+    # Add unique id columns
+    table = table.append_column(
+        pa.field("secondary_substation_unique_id", pa.string()),
+        pc.utf8_slice_codeunits(table.column("dataset_id"), 0, 10),
+    )
+    table = table.append_column(
+        pa.field("lv_feeder_unique_id", pa.string()),
+        table.column("dataset_id"),
+    )
+
+    # Cast floats to int
+    table = table.set_column(
+        table.column_names.index("aggregated_device_count_active"),
+        pa.field("aggregated_device_count_active", pa.int64()),
+        pc.cast(pc.round(table.column("aggregated_device_count_active")), pa.int64()),
+    )
+    table = table.set_column(
+        table.column_names.index("total_consumption_active_import"),
+        pa.field("total_consumption_active_import", pa.int64()),
+        pc.cast(pc.round(table.column("total_consumption_active_import")), pa.int64()),
+    )
+
+    # Cast datetime to timestamp
+    table = table.set_column(
+        table.column_names.index("data_collection_log_timestamp"),
+        pa.field("data_collection_log_timestamp", pa.timestamp("ms", tz="UTC")),
+        pc.cast(
+            table.column("data_collection_log_timestamp"), pa.timestamp("ms", tz="UTC")
+        ),
+    )
+
+    return table.select(
+        [
+            "dataset_id",
+            "dno_alias",
+            "aggregated_device_count_active",
+            "total_consumption_active_import",
+            "data_collection_log_timestamp",
+            "geometry",
+            "secondary_substation_unique_id",
+            "lv_feeder_unique_id",
+        ]
+    )

--- a/weave/assets/dno_lv_feeder_combined_geoparquet.py
+++ b/weave/assets/dno_lv_feeder_combined_geoparquet.py
@@ -99,7 +99,7 @@ def lv_feeder_combined_geoparquet(
                 ).as_py()
 
                 processed_rows += table.num_rows
-                percentage_processed = processed_rows / total_rows * 100
+                percentage_processed = int(processed_rows / total_rows * 100)
                 context.log.info(
                     f"Processed {processed_rows} rows ({percentage_processed}% of total)"
                 )

--- a/weave/core.py
+++ b/weave/core.py
@@ -1,5 +1,8 @@
+import json
 from enum import Enum
 
+import pyarrow as pa
+import pyproj
 from pydantic import BaseModel, HttpUrl
 
 
@@ -24,3 +27,48 @@ class AvailableFile(BaseModel):
 
     def __lt__(self, other):
         return self.filename < other.filename
+
+
+lv_feeder_geoparquet_schema = pa.schema(
+    [
+        ("dataset_id", pa.string()),
+        ("dno_alias", pa.string()),
+        ("aggregated_device_count_active", pa.int64()),
+        ("total_consumption_active_import", pa.int64()),
+        ("data_collection_log_timestamp", pa.timestamp("ms", tz="UTC")),
+        (
+            pa.field(
+                "geometry",
+                pa.struct(
+                    [
+                        pa.field("x", pa.float64(), nullable=False),
+                        pa.field("y", pa.float64(), nullable=False),
+                    ]
+                ),
+                metadata={
+                    "ARROW:extension:name": "geoarrow.point",
+                    "ARROW:extension:metadata": json.dumps(
+                        {"crs": pyproj.CRS.from_string("EPSG:4326").to_json()}
+                    ),
+                },
+            )
+        ),
+        ("secondary_substation_unique_id", pa.string()),
+        ("lv_feeder_unique_id", pa.string()),
+    ],
+    metadata={
+        b"geo": json.dumps(
+            {
+                "primary_column": "geometry",
+                "columns": {
+                    "geometry": {
+                        "encoding": "point",
+                        "crs": pyproj.CRS.from_string("EPSG:4326").to_json(),
+                        "geometry_types": ["Point"],
+                    }
+                },
+                "schema_version": "1.1.0",
+            }
+        ).encode("utf-8"),
+    },
+)

--- a/weave/definitions.py
+++ b/weave/definitions.py
@@ -3,6 +3,7 @@ import os
 from dagster import Definitions, load_assets_from_modules
 
 from .assets import (
+    dno_lv_feeder_combined_geoparquet,
     dno_lv_feeder_files,
     dno_lv_feeder_monthly_parquet,
     ons,
@@ -14,7 +15,13 @@ from .resources.ssen import LiveSSENAPIClient
 from .sensors import ssen_lv_feeder_files_sensor, ssen_lv_feeder_monthly_parquet_sensor
 
 all_assets = load_assets_from_modules(
-    [dno_lv_feeder_files, dno_lv_feeder_monthly_parquet, ssen_substation_locations, ons]
+    [
+        dno_lv_feeder_files,
+        dno_lv_feeder_monthly_parquet,
+        ssen_substation_locations,
+        ons,
+        dno_lv_feeder_combined_geoparquet,
+    ]
 )
 
 CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -29,6 +36,9 @@ resources = {
         "staging_files_resource": OutputFilesResource(
             url=f"file://{os.path.join(DATA_DIR, "staging")}"
         ),
+        "output_files_resource": OutputFilesResource(
+            url=f"file://{os.path.join(DATA_DIR, "output", "beta")}"
+        ),
         "ssen_api_client": LiveSSENAPIClient(),
         "ons_api_client": LiveONSAPIClient(),
     },
@@ -37,6 +47,7 @@ resources = {
         "staging_files_resource": OutputFilesResource(
             url="s3://weave.energy-dev/data/staging"
         ),
+        "output_files_resource": OutputFilesResource(url="s3://weave.energy-dev/beta"),
         "ssen_api_client": LiveSSENAPIClient(),
         "ons_api_client": LiveONSAPIClient(),
     },
@@ -47,6 +58,9 @@ resources = {
         "staging_files_resource": OutputFilesResource(
             url=f"s3://weave.energy-branches/{os.getenv("DAGSTER_CLOUD_GIT_BRANCH")}/data/staging"
         ),
+        "output_files_resource": OutputFilesResource(
+            url=f"s3://weave.energy-branches/{os.getenv("DAGSTER_CLOUD_GIT_BRANCH")}/beta"
+        ),
         "ssen_api_client": LiveSSENAPIClient(),
         "ons_api_client": LiveONSAPIClient(),
     },
@@ -55,6 +69,7 @@ resources = {
         "staging_files_resource": OutputFilesResource(
             url="s3://weave.energy/data/staging"
         ),
+        "output_files_resource": OutputFilesResource(url="s3://weave.energy/beta"),
         "ssen_api_client": LiveSSENAPIClient(),
         "ons_api_client": LiveONSAPIClient(),
     },

--- a/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
+++ b/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
@@ -3,7 +3,9 @@ from calendar import monthrange
 
 import geopandas as gpd
 import pandas as pd
+import pyproj
 from dagster import build_asset_context
+from shapely import Point
 
 from weave.assets.dno_lv_feeder_combined_geoparquet import lv_feeder_combined_geoparquet
 from weave.resources.output_files import OutputFilesResource
@@ -45,8 +47,8 @@ def ssen_lv_feeder_monthly_parquet_factory(month: int):
                         "lv_feeder_id": feeder_id,
                         "lv_feeder_name": "",
                         "substation_geo_location": locations[substation_idx],
-                        "aggregated_device_count_active": 15.0,
-                        "total_consumption_active_import": 2331.0,
+                        "aggregated_device_count_active": 15.3,
+                        "total_consumption_active_import": 2331.5,
                         "data_collection_log_timestamp": f"2024-{month:02d}-{day:02d}T00:30:00.000Z",
                         "insert_time": f"2024-{month + 1:02d}-14T00:07:06.000Z",
                         "last_modified_time": f"2024-{month + 1:02d}-25T12:46:46.298Z",
@@ -55,12 +57,11 @@ def ssen_lv_feeder_monthly_parquet_factory(month: int):
     return data
 
 
-def create_monthly_parquet_files(dir):
-    for month in range(1, 13):
-        data = ssen_lv_feeder_monthly_parquet_factory(month)
-        monthly_file = dir / f"2024-{month:02d}.parquet"
-        df = pd.DataFrame(data=data)
-        df.to_parquet(monthly_file)
+def create_monthly_parquet_files(dir, month):
+    data = ssen_lv_feeder_monthly_parquet_factory(month)
+    monthly_file = dir / f"2024-{month:02d}.parquet"
+    df = pd.DataFrame.from_records(data=data)
+    df.to_parquet(monthly_file)
 
 
 def test_lv_feeder_combined_geoparquet(tmp_path):
@@ -69,9 +70,9 @@ def test_lv_feeder_combined_geoparquet(tmp_path):
     output_dir = tmp_path / "output"
     output_dir.mkdir()
 
-    create_monthly_parquet_files(input_dir)
+    create_monthly_parquet_files(input_dir, 2)
 
-    context = build_asset_context()
+    context = build_asset_context(partition_key="2024-02-01")
     staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
     output_files_resource = OutputFilesResource(url=(tmp_path / "output").as_uri())
 
@@ -79,8 +80,8 @@ def test_lv_feeder_combined_geoparquet(tmp_path):
         context, staging_files_resource, output_files_resource
     )
 
-    gdf = gpd.read_parquet(output_dir / "smart-meter.parquet")
-    assert len(gdf) == 6 * 366  # 6 feeders  * 366 days (2024 was a leap year)
+    gdf = gpd.read_parquet(output_dir / "smart-meter" / "2024-02.parquet")
+    assert len(gdf) == 6 * 29  # 6 feeders * 29 days (2024 was a leap year)
 
     assert gdf.columns.tolist() == [
         "dataset_id",
@@ -93,10 +94,45 @@ def test_lv_feeder_combined_geoparquet(tmp_path):
         "lv_feeder_unique_id",
     ]
 
-    # TODO:
-    # Test expected dtypes
-    # Test all the data is there
-    # Test geometry is correct (within UK)
-    # Test floats coerced to ints properly
-    # SSEN-specific tests:
-    # - Test substation and feeder ids come from dataset_id
+    # Dataframe has correct geo-metadata
+    assert gdf.crs == pyproj.CRS.from_string("EPSG:4326")
+
+    # Dataframe is ordered by:
+    # timestamp, dno (moot atm), substation, feeder
+    assert gdf.iloc[0].data_collection_log_timestamp == pd.Timestamp(
+        "2024-02-01 00:30:00+0000", tz="UTC"
+    )
+    assert gdf.iloc[0].secondary_substation_unique_id == "0002002001"
+    assert gdf.iloc[0].lv_feeder_unique_id == "000200200101"
+
+    assert gdf.iloc[1].data_collection_log_timestamp == pd.Timestamp(
+        "2024-02-01 00:30:00+0000", tz="UTC"
+    )
+    assert gdf.iloc[1].secondary_substation_unique_id == "0002002001"
+    assert gdf.iloc[1].lv_feeder_unique_id == "000200200102"
+
+    assert gdf.iloc[2].data_collection_log_timestamp == pd.Timestamp(
+        "2024-02-01 00:30:00+0000", tz="UTC"
+    )
+    assert gdf.iloc[2].secondary_substation_unique_id == "0002002002"
+    assert gdf.iloc[2].lv_feeder_unique_id == "000200200201"
+
+    assert gdf.iloc[-1].data_collection_log_timestamp == pd.Timestamp(
+        "2024-02-29 00:30:00+0000", tz="UTC"
+    )
+    assert gdf.iloc[-1].secondary_substation_unique_id == "0002002003"
+    assert gdf.iloc[-1].lv_feeder_unique_id == "000200200302"
+
+    # Locations are parsed to geometries correctly (including empty ones)
+    assert gdf.iloc[0].geometry == Point(-2.43, 50.79)
+    assert gdf.iloc[2].geometry == Point(-2.43, 51.79)
+    assert gdf.iloc[4].geometry == Point()
+
+    # Numbers are rounded to ints
+    assert gdf.iloc[0].aggregated_device_count_active == 15
+    assert gdf.iloc[0].total_consumption_active_import == 2332
+
+    # SSEN substations have their ids taken from the dataset_id
+    assert gdf.iloc[0].dataset_id == "000200200101"
+    assert gdf.iloc[0].secondary_substation_unique_id == "0002002001"
+    assert gdf.iloc[0].lv_feeder_unique_id == "000200200101"

--- a/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
+++ b/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
@@ -1,0 +1,102 @@
+import os
+from calendar import monthrange
+
+import geopandas as gpd
+import pandas as pd
+from dagster import build_asset_context
+
+from weave.assets.dno_lv_feeder_combined_geoparquet import lv_feeder_combined_geoparquet
+from weave.resources.output_files import OutputFilesResource
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)),
+    "..",
+    "fixtures",
+)
+
+
+def ssen_lv_feeder_monthly_parquet_factory(month: int):
+    """Very basic test data factory for SSEN LV Feeder mothly parquet files.
+
+    Makes one row of data per day of the given month, for 3 substations, with two
+    feeders per substation.
+
+    Each substation is located at a different lat/lng, with one missing a location."""
+
+    substation_ids = ["001", "002", "003"]
+    substation_names = ["DUNCRAIG ROAD", "MANOR FARM", "PLAYING PLACE"]
+    feeder_ids = ["01", "02"]
+    locations = ["50.79,-2.43", "51.79,-2.43", None]
+
+    data = []
+
+    days_in_month = monthrange(2024, month)[1]
+
+    for day in range(1, days_in_month + 1):
+        for substation_idx, substation_id in enumerate(substation_ids):
+            for feeder_id in feeder_ids:
+                data.append(
+                    {
+                        "dataset_id": f"0002002{substation_id}{feeder_id}",
+                        "dno_name": "Scottish and Southern Electricity Networks",
+                        "dno_alias": "SSEN",
+                        "secondary_substation_id": substation_id,
+                        "secondary_substation_name": substation_names[substation_idx],
+                        "lv_feeder_id": feeder_id,
+                        "lv_feeder_name": "",
+                        "substation_geo_location": locations[substation_idx],
+                        "aggregated_device_count_active": 15.0,
+                        "total_consumption_active_import": 2331.0,
+                        "data_collection_log_timestamp": f"2024-{month:02d}-{day:02d}T00:30:00.000Z",
+                        "insert_time": f"2024-{month + 1:02d}-14T00:07:06.000Z",
+                        "last_modified_time": f"2024-{month + 1:02d}-25T12:46:46.298Z",
+                    }
+                )
+    return data
+
+
+def create_monthly_parquet_files(dir):
+    for month in range(1, 13):
+        data = ssen_lv_feeder_monthly_parquet_factory(month)
+        monthly_file = dir / f"2024-{month:02d}.parquet"
+        df = pd.DataFrame(data=data)
+        df.to_parquet(monthly_file)
+
+
+def test_lv_feeder_combined_geoparquet(tmp_path):
+    input_dir = tmp_path / "staging" / "ssen"
+    input_dir.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    create_monthly_parquet_files(input_dir)
+
+    context = build_asset_context()
+    staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
+    output_files_resource = OutputFilesResource(url=(tmp_path / "output").as_uri())
+
+    lv_feeder_combined_geoparquet(
+        context, staging_files_resource, output_files_resource
+    )
+
+    gdf = gpd.read_parquet(output_dir / "smart-meter.parquet")
+    assert len(gdf) == 6 * 366  # 6 feeders  * 366 days (2024 was a leap year)
+
+    assert gdf.columns.tolist() == [
+        "dataset_id",
+        "dno_alias",
+        "aggregated_device_count_active",
+        "total_consumption_active_import",
+        "data_collection_log_timestamp",
+        "geometry",
+        "secondary_substation_unique_id",
+        "lv_feeder_unique_id",
+    ]
+
+    # TODO:
+    # Test expected dtypes
+    # Test all the data is there
+    # Test geometry is correct (within UK)
+    # Test floats coerced to ints properly
+    # SSEN-specific tests:
+    # - Test substation and feeder ids come from dataset_id


### PR DESCRIPTION
This is a first attempt at sticking together geoparquet files from the
raw dno data. Some key points:

- Data is output in monthly partitions, but this is done manually rather
  than using pyarrow to understand the partitions, so that we can do
  them individually
- We do not write a _metadata or _common_metadata file, because how to
  do that for GeoParquet is not actually decided yet
- We use geopandas to do the tricky bit of creating a geometry column,
  rather than pyarrow directly. This isn't _too_ slow, but is a shame,
  partly because we have to use some geopandas internals to do it too.
- Right now it only deals with SSEN data, it will need to be expanded
  and probably refactored later.
- The final output is under a beta/smart-meter folder, so that we keep
  our original prototype data for now.
- I have changed the float rounding to half-even - probably an
  inconsequential choice for our usecase, but it was available and
  seemed better, so I used it.