### PR TITLE
Fix #18: Handle missing inputs in monthly parquet

### DIFF
--- a/weave/assets/dno_lv_feeder_monthly_parquet.py
+++ b/weave/assets/dno_lv_feeder_monthly_parquet.py
@@ -96,6 +96,10 @@ def ssen_lv_feeder_monthly_parquet(
                 )
         parquet_writer.close()
 
+    if metadata["dagster/row_count"] == 0:
+        context.log.info(f"No data found for {monthly_file}, deleting empty file")
+        staging_files_resource.delete(DNO.SSEN.value, monthly_file)
+
     return MaterializeResult(metadata=metadata)
 
 

--- a/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
+++ b/weave_tests/assets/test_dno_lv_feeder_combined_geoparquet.py
@@ -136,3 +136,23 @@ def test_lv_feeder_combined_geoparquet(tmp_path):
     assert gdf.iloc[0].dataset_id == "000200200101"
     assert gdf.iloc[0].secondary_substation_unique_id == "0002002001"
     assert gdf.iloc[0].lv_feeder_unique_id == "000200200101"
+
+
+def test_lv_feeder_combined_geoparquet_handles_missing_input(tmp_path):
+    input_dir = tmp_path / "staging" / "ssen"
+    input_dir.mkdir(parents=True)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # We haven't made any monthly files, so there's nothing to combine
+
+    context = build_asset_context(partition_key="2024-02-01")
+    staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
+    output_files_resource = OutputFilesResource(url=(tmp_path / "output").as_uri())
+
+    # Shouldn't raise, this is an expected situation at the beginning of the month
+    lv_feeder_combined_geoparquet(
+        context, staging_files_resource, output_files_resource
+    )
+
+    assert not (output_dir / "smart-meter" / "2024-02.parquet").exists()


### PR DESCRIPTION
Dagster creates monthly assets as soon as the month starts, but the daily inputs lag behind a bit - often we don't have the data for the 1st until the 5th or 6th. Before this change, we would output an empty file for the monthly raw data, then the partition run for the final output file would crash when reading that empty file.

This commit makes two changes to handle this situation:
1. Stop outputting empty files for the monthly raw data
2. Catch errors in the combined output asset so we're robust to missing inputs

Both of these are made a bit more complex by the fact that we're streaming data into files, so we open them before we find out things are missing. This means we need to delete files to tidy up after ourselves.

This is another pointer that the way we're linking our dynamic raw files to monthly partitions is a bit fragile, but I'm not sure what to do about it.

Fixes #18 