### PR TITLE
Add Monthly Parquet files for NGED feeder data

### DIFF
--- a/weave/core.py
+++ b/weave/core.py
@@ -32,6 +32,23 @@ class AvailableFile(BaseModel):
         )
 
 
+lv_feeder_parquet_schema = pa.schema(
+    [
+        ("dataset_id", pa.string()),
+        ("dno_alias", pa.string()),
+        ("secondary_substation_id", pa.string()),
+        ("secondary_substation_name", pa.string()),
+        ("lv_feeder_id", pa.string()),
+        ("lv_feeder_name", pa.string()),
+        ("substation_geo_location", pa.string()),
+        ("aggregated_device_count_active", pa.float64()),
+        ("total_consumption_active_import", pa.float64()),
+        ("data_collection_log_timestamp", pa.timestamp("ms", tz="UTC")),
+        ("insert_time", pa.timestamp("ms", tz="UTC")),
+        ("last_modified_time", pa.timestamp("ms", tz="UTC")),
+    ]
+)
+
 lv_feeder_geoparquet_schema = pa.schema(
     [
         ("dataset_id", pa.string()),

--- a/weave/dagster_helpers.py
+++ b/weave/dagster_helpers.py
@@ -1,0 +1,32 @@
+from dagster import AssetKey, AssetRecordsFilter, DagsterInstance, LoggerDefinition
+
+
+def get_materialisations(
+    instance: DagsterInstance,
+    log: LoggerDefinition,
+    asset_key: AssetKey,
+    after_storage_id: int = None,
+):
+    has_more = True
+    materialisations = []
+    cursor = None
+    while has_more:
+        result = instance.fetch_materializations(
+            AssetRecordsFilter(
+                asset_key=asset_key,
+                after_storage_id=after_storage_id,
+            ),
+            # Dagster cloud has a limit of 1000
+            limit=1000,
+            cursor=cursor,
+            ascending=True,
+        )
+        materialisations.extend(result.records)
+        cursor = result.cursor
+        has_more = result.has_more
+
+    log.info(
+        f"Found {len(materialisations)} matching materialisation events for {asset_key}"
+    )
+
+    return materialisations

--- a/weave/definitions.py
+++ b/weave/definitions.py
@@ -15,6 +15,7 @@ from .resources.output_files import OutputFilesResource
 from .resources.ssen import LiveSSENAPIClient
 from .sensors import (
     nged_lv_feeder_files_sensor,
+    nged_lv_feeder_monthly_parquet_sensor,
     ssen_lv_feeder_files_sensor,
     ssen_lv_feeder_monthly_parquet_sensor,
     ssen_lv_feeder_postcode_mapping_sensor,
@@ -128,6 +129,7 @@ defs = Definitions(
         ssen_lv_feeder_monthly_parquet_sensor,
         ssen_lv_feeder_postcode_mapping_sensor,
         nged_lv_feeder_files_sensor,
+        nged_lv_feeder_monthly_parquet_sensor,
     ],
     resources=resources[deployment_name()],
 )

--- a/weave/resources/ssen.py
+++ b/weave/resources/ssen.py
@@ -34,7 +34,7 @@ class SSENAPIClient(ConfigurableResource, ABC):
             "resource_id": "1cce1fb4-d7f4-4309-b9e3-943bd4d18618",
         }
     }
-    lv_feeder_pyarrow_schema: ClassVar = pa.schema(
+    lv_feeder_csv_schema: ClassVar = pa.schema(
         [
             ("dataset_id", pa.string()),
             ("dno_alias", pa.string()),
@@ -110,21 +110,8 @@ class SSENAPIClient(ConfigurableResource, ABC):
     def lv_feeder_file_pyarrow_table(self, input_file: OpenFile):
         """Read an LV Feeder CSV file into a PyArrow Table."""
         pyarrow_csv_convert_options = pa_csv.ConvertOptions(
-            column_types=self.lv_feeder_pyarrow_schema,
-            include_columns=[
-                "dataset_id",
-                "dno_alias",
-                "secondary_substation_id",
-                "secondary_substation_name",
-                "lv_feeder_id",
-                "lv_feeder_name",
-                "substation_geo_location",
-                "aggregated_device_count_active",
-                "total_consumption_active_import",
-                "data_collection_log_timestamp",
-                "insert_time",
-                "last_modified_time",
-            ],
+            column_types=self.lv_feeder_csv_schema,
+            include_columns=self.lv_feeder_csv_schema.names,
         )
         with gzip_ng_threaded.open(input_file, "rb", threads=pa.io_thread_count()) as f:
             return pa_csv.read_csv(f, convert_options=pyarrow_csv_convert_options)

--- a/weave_tests/assets/test_dno_lv_feeder_files.py
+++ b/weave_tests/assets/test_dno_lv_feeder_files.py
@@ -6,7 +6,7 @@ import pytest
 from dagster import build_asset_context
 
 from weave.assets.dno_lv_feeder_files import nged_lv_feeder_files, ssen_lv_feeder_files
-from weave.resources.nged import StubNGEDAPICLient
+from weave.resources.nged import StubNGEDAPIClient
 from weave.resources.output_files import OutputFilesResource
 from weave.resources.ssen import StubSSENAPICLient
 
@@ -68,7 +68,7 @@ class TestNGEDLVFeederFiles:
             partition_key="https://connecteddata.nationalgrid.co.uk/dataset/a920c581-9c6f-4788-becc-9d2caf20050c/resource/105a7821-7f5c-4591-90e8-5915f253b1ff/download/aggregated-smart-meter-data-lv-feeder-2024-01-part0000.csv"
         )
         raw_files_resource = OutputFilesResource(url=tmp_path.as_uri())
-        api_client = StubNGEDAPICLient(
+        api_client = StubNGEDAPIClient(
             api_token="TEST",
             file_to_download=os.path.join(
                 FIXTURE_DIR,

--- a/weave_tests/assets/test_dno_lv_feeder_monthly_parquet.py
+++ b/weave_tests/assets/test_dno_lv_feeder_monthly_parquet.py
@@ -1,10 +1,15 @@
 import os
 
 import pandas as pd
-from dagster import build_asset_context
+from dagster import AssetKey, AssetMaterialization, DagsterInstance, build_asset_context
 from zlib_ng import zlib_ng
 
-from weave.assets.dno_lv_feeder_monthly_parquet import ssen_lv_feeder_monthly_parquet
+from weave.assets.dno_lv_feeder_monthly_parquet import (
+    nged_lv_feeder_monthly_parquet,
+    ssen_lv_feeder_monthly_parquet,
+)
+from weave.core import lv_feeder_parquet_schema
+from weave.resources.nged import StubNGEDAPIClient
 from weave.resources.output_files import OutputFilesResource
 from weave.resources.ssen import StubSSENAPICLient
 
@@ -15,112 +20,178 @@ FIXTURE_DIR = os.path.join(
 )
 
 
-def create_daily_files(year, month, start, end, dir):
-    # 4 different secondary substations with 2 feeders each, one will have locations
-    # from the postcodes lookup and the other from the transformer load model, the final
-    # one will remain blank
-    input_file = os.path.join(
-        FIXTURE_DIR, "ssen", "lv_feeder_files", "2024-02-12_for_location_lookup.csv"
-    )
-    for day in range(start, end):
-        filename = dir / f"{year}-{month:02d}-{day:02d}.csv.gz"
-        with open(filename.as_posix(), "wb") as output_file:
-            with open(input_file, "rb") as f:
-                output_file.write(
-                    zlib_ng.compress(f.read(), level=1, wbits=zlib_ng.MAX_WBITS | 16)
+class TestSSENLVFeederMonthlyParquet:
+    @staticmethod
+    def create_daily_files(year, month, start, end, dir):
+        input_file = os.path.join(
+            FIXTURE_DIR, "ssen", "lv_feeder_files", "2024-02-12_for_location_lookup.csv"
+        )
+        for day in range(start, end):
+            filename = dir / f"{year}-{month:02d}-{day:02d}.csv.gz"
+            with open(filename.as_posix(), "wb") as output_file:
+                with open(input_file, "rb") as f:
+                    output_file.write(
+                        zlib_ng.compress(
+                            f.read(), level=1, wbits=zlib_ng.MAX_WBITS | 16
+                        )
+                    )
+
+    @staticmethod
+    def create_substation_location_lookup_postcodes(dir):
+        data = {
+            "substation_nrn": ["0002002004", "0002002009"],
+            "substation_geo_location": ["50.79,-2.43", "49.79,-1.43"],
+        }
+        df = pd.DataFrame(data=data)
+        df.to_parquet(dir / "substation_location_lookup_feeder_postcodes.parquet")
+
+    @staticmethod
+    def substation_location_lookup_load_model(dir):
+        data = {
+            "substation_nrn": ["0002002004"],
+            "substation_geo_location": ["51.79,-2.53"],
+        }
+        df = pd.DataFrame(data=data)
+        df.to_parquet(dir / "substation_location_lookup_transformer_load_model.parquet")
+
+    def test_happy_path(self, tmp_path):
+        output_dir = tmp_path / "staging" / "ssen"
+        output_dir.mkdir(parents=True)
+        input_dir = tmp_path / "raw" / "ssen"
+        input_dir.mkdir(parents=True)
+
+        self.create_daily_files(2024, 2, 1, 30, input_dir)
+        self.create_substation_location_lookup_postcodes(output_dir)
+        self.substation_location_lookup_load_model(output_dir)
+
+        context = build_asset_context(partition_key="2024-02-01")
+        staging_files_resource = OutputFilesResource(
+            url=(tmp_path / "staging").as_uri()
+        )
+        raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+        ssen_api_client = StubSSENAPICLient()
+
+        ssen_lv_feeder_monthly_parquet(
+            context, raw_files_resource, staging_files_resource, ssen_api_client
+        )
+
+        df = pd.read_parquet(output_dir / "2024-02.parquet", engine="pyarrow")
+        assert len(df) == 6 * 29
+        assert (
+            df[df["dataset_id"] == "000200200402"].iloc[0].substation_geo_location
+            == "51.79,-2.53"
+        )
+        assert (
+            df[df["dataset_id"] == "000200200404"].iloc[0].substation_geo_location
+            == "51.79,-2.53"
+        )
+        assert (
+            df[df["dataset_id"] == "000200200901"].iloc[0].substation_geo_location
+            == "49.79,-1.43"
+        )
+        assert (
+            df[df["dataset_id"] == "000200200902"].iloc[0].substation_geo_location
+            == "49.79,-1.43"
+        )
+        assert (
+            df[df["dataset_id"] == "000200202002"].iloc[0].substation_geo_location
+            is None
+        )
+        assert (
+            df[df["dataset_id"] == "000200202003"].iloc[0].substation_geo_location
+            is None
+        )
+
+    def test_when_missing_input(self, tmp_path):
+        output_dir = tmp_path / "staging" / "ssen"
+        output_dir.mkdir(parents=True)
+        input_dir = tmp_path / "raw" / "ssen"
+        input_dir.mkdir(parents=True)
+
+        self.create_substation_location_lookup_postcodes(output_dir)
+        self.substation_location_lookup_load_model(output_dir)
+
+        context = build_asset_context(partition_key="2024-02-01")
+        staging_files_resource = OutputFilesResource(
+            url=(tmp_path / "staging").as_uri()
+        )
+        raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+        ssen_api_client = StubSSENAPICLient()
+
+        ssen_lv_feeder_monthly_parquet(
+            context, raw_files_resource, staging_files_resource, ssen_api_client
+        )
+
+        assert not (output_dir / "2024-02.parquet").exists()
+
+
+class TestNGEDLVFeederMonthlyParquet:
+    def test_happy_path(self, tmp_path):
+        instance = DagsterInstance.ephemeral()
+
+        output_dir = tmp_path / "staging" / "nged"
+        output_dir.mkdir(parents=True)
+        input_dir = tmp_path / "raw" / "nged"
+        input_dir.mkdir(parents=True)
+
+        fixture_file = os.path.join(
+            FIXTURE_DIR,
+            "nged",
+            "lv_feeder_files",
+            "aggregated-smart-meter-data-lv-feeder-2024-01-part0000_head.csv",
+        )
+        for part in range(10):
+            filename = (
+                f"aggregated-smart-meter-data-lv-feeder-2024-01-part{part:04d}.csv"
+            )
+            partition = f"http://example.com/{filename}"
+            with open((input_dir / f"{filename}.gz").as_posix(), "wb") as output_file:
+                with open(fixture_file, "rb") as f:
+                    output_file.write(
+                        zlib_ng.compress(
+                            f.read(), level=1, wbits=zlib_ng.MAX_WBITS | 16
+                        )
+                    )
+            instance.report_runless_asset_event(
+                AssetMaterialization(
+                    asset_key=AssetKey("nged_lv_feeder_files"), partition=partition
                 )
+            )
 
+        context = build_asset_context(partition_key="2024-01-01", instance=instance)
+        staging_files_resource = OutputFilesResource(
+            url=(tmp_path / "staging").as_uri()
+        )
+        raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+        nged_api_client = StubNGEDAPIClient()
 
-def create_substation_location_lookup_postcodes(dir):
-    data = {
-        "substation_nrn": ["0002002004", "0002002009"],
-        "substation_geo_location": ["50.79,-2.43", "49.79,-1.43"],
-    }
-    df = pd.DataFrame(data=data)
-    df.to_parquet(dir / "substation_location_lookup_feeder_postcodes.parquet")
+        result = nged_lv_feeder_monthly_parquet(
+            context, raw_files_resource, staging_files_resource, nged_api_client
+        )
 
+        df = pd.read_parquet(output_dir / "2024-01.parquet", engine="pyarrow")
+        assert len(df) == 100
+        assert df.columns.tolist() == lv_feeder_parquet_schema.names
+        assert result.metadata["dagster/row_count"] == 100
+        assert result.metadata["weave/nunique_feeders"] == 1
 
-def substation_location_lookup_load_model(dir):
-    data = {
-        # Only one substation in the lookup so we can we fall back to the postcode lookup
-        "substation_nrn": ["0002002004"],
-        # Different location for the first to the postcode lookup so we can tell its been used
-        "substation_geo_location": ["51.79,-2.53"],
-    }
-    df = pd.DataFrame(data=data)
-    df.to_parquet(dir / "substation_location_lookup_transformer_load_model.parquet")
+    def test_when_missing_input(self, tmp_path):
+        output_dir = tmp_path / "staging" / "ssen"
+        output_dir.mkdir(parents=True)
+        input_dir = tmp_path / "raw" / "ssen"
+        input_dir.mkdir(parents=True)
 
+        context = build_asset_context(partition_key="2024-01-01")
+        staging_files_resource = OutputFilesResource(
+            url=(tmp_path / "staging").as_uri()
+        )
+        raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
+        nged_api_client = StubNGEDAPIClient()
 
-def test_ssen_lv_feeder_monthly_parquet(tmp_path):
-    output_dir = tmp_path / "staging" / "ssen"
-    output_dir.mkdir(parents=True)
-    input_dir = tmp_path / "raw" / "ssen"
-    input_dir.mkdir(parents=True)
+        result = nged_lv_feeder_monthly_parquet(
+            context, raw_files_resource, staging_files_resource, nged_api_client
+        )
 
-    create_daily_files(2024, 2, 1, 30, input_dir)  # 2024 was a leap year hence 29 days
-    create_substation_location_lookup_postcodes(output_dir)
-    substation_location_lookup_load_model(output_dir)
-
-    context = build_asset_context(partition_key="2024-02-01")
-    staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
-    raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
-    ssen_api_client = StubSSENAPICLient()
-
-    ssen_lv_feeder_monthly_parquet(
-        context, raw_files_resource, staging_files_resource, ssen_api_client
-    )
-
-    df = pd.read_parquet(output_dir / "2024-02.parquet", engine="pyarrow")
-    assert len(df) == 6 * 29  # 6 rows in the fixture * 29 days
-    # Locations in the load model should override the postcode lookup
-    assert (
-        df[df["dataset_id"] == "000200200402"].iloc[0].substation_geo_location
-        == "51.79,-2.53"
-    )
-    # All feeders should get the same substation location
-    assert (
-        df[df["dataset_id"] == "000200200404"].iloc[0].substation_geo_location
-        == "51.79,-2.53"
-    )
-    # If there's no location in the load model we should use the postcode lookup
-    assert (
-        df[df["dataset_id"] == "000200200901"].iloc[0].substation_geo_location
-        == "49.79,-1.43"
-    )
-    # All feeders should get the same substation location, even when using the postcode
-    # lookup
-    assert (
-        df[df["dataset_id"] == "000200200902"].iloc[0].substation_geo_location
-        == "49.79,-1.43"
-    )
-    # If there's no location in the load model or postcode lookup it should stay blank
-    assert (
-        df[df["dataset_id"] == "000200202002"].iloc[0].substation_geo_location is None
-    )
-    # All feeders should get a blank substation location if there is none in either
-    # lookup
-    assert (
-        df[df["dataset_id"] == "000200202003"].iloc[0].substation_geo_location is None
-    )
-
-
-def test_ssen_lv_feeder_monthly_parquet_when_missing_input(tmp_path):
-    output_dir = tmp_path / "staging" / "ssen"
-    output_dir.mkdir(parents=True)
-    input_dir = tmp_path / "raw" / "ssen"
-    input_dir.mkdir(parents=True)
-
-    # No input daily files
-    create_substation_location_lookup_postcodes(output_dir)
-    substation_location_lookup_load_model(output_dir)
-
-    context = build_asset_context(partition_key="2024-02-01")
-    staging_files_resource = OutputFilesResource(url=(tmp_path / "staging").as_uri())
-    raw_files_resource = OutputFilesResource(url=(tmp_path / "raw").as_uri())
-    ssen_api_client = StubSSENAPICLient()
-
-    ssen_lv_feeder_monthly_parquet(
-        context, raw_files_resource, staging_files_resource, ssen_api_client
-    )
-
-    assert not (output_dir / "2024-02.parquet").exists()
+        assert not (output_dir / "2024-01.parquet").exists()
+        assert result.metadata["dagster/row_count"] == 0
+        assert result.metadata["weave/nunique_feeders"] == 0

--- a/weave_tests/test_dagster_helpers.py
+++ b/weave_tests/test_dagster_helpers.py
@@ -1,0 +1,33 @@
+from dagster import AssetKey, AssetMaterialization, DagsterInstance, build_asset_context
+
+from weave.dagster_helpers import get_materialisations
+
+
+def test_get_materialisations_pagination():
+    instance = DagsterInstance.ephemeral()
+    context = build_asset_context(instance=instance)
+    log = context.log
+    asset_key = AssetKey("test")
+    for i in range(1001):
+        instance.report_runless_asset_event(AssetMaterialization(asset_key=asset_key))
+    materialisations = get_materialisations(instance, log, asset_key)
+    assert len(materialisations) == 1001
+
+
+def test_get_materialisations_storage_id_filtering():
+    instance = DagsterInstance.ephemeral()
+    context = build_asset_context(instance=instance)
+    log = context.log
+    asset_key = AssetKey("test")
+    instance.report_runless_asset_event(AssetMaterialization(asset_key=asset_key))
+    materialisations = get_materialisations(instance, log, asset_key)
+    assert len(materialisations) == 1
+
+    first_storage_id = materialisations[0].storage_id
+    materialisations = get_materialisations(instance, log, asset_key, first_storage_id)
+    assert len(materialisations) == 0
+
+    instance.report_runless_asset_event(AssetMaterialization(asset_key=asset_key))
+    materialisations = get_materialisations(instance, log, asset_key, first_storage_id)
+    assert len(materialisations) == 1
+    assert materialisations[0].storage_id != first_storage_id


### PR DESCRIPTION
This is the next part of work towards #17 - Adding NGED data. I've followed the approach I took with SSEN, namely having an intermediate monthly partitioned asset, which reflects the source data pretty much as-is, but just aggregates it into monthly files and conforms it to the standard schema. This is a base on which we can then do any data quality analysis we need, before merging into the combined geoparquet files.

As part of this, I made a few other fixes and refactorings:
- Split the PyArrow schema for reading raw CSV files and writing the output monthly parquet, so we have one in each API client that represents that DNO's CSV schema and then a "core" one that represents the standardised one we output monthly files to. In SSEN's case they were the same, but NGED's CSV files have some weird column naming capitalisation so I've split them all up. 
- Fixed a bug with double-counting unique feeders in SSEN's data whilst streaming CSVs into the parquet file in chunks
- Used the more lightweight `report_runless_asset_event` way of creating asset materialisation records in Dagster in all sensor tests, so we don't need to actually materialise things to test sensors that query Dagster