### PR TITLE
Only update latest SSEN month when locations update

### DIFF
--- a/weave/assets/dno_lv_feeder_monthly_parquet.py
+++ b/weave/assets/dno_lv_feeder_monthly_parquet.py
@@ -16,7 +16,7 @@ from dagster import (
 )
 from fsspec.core import OpenFile
 
-from ..automation_conditions import lv_feeder_monthly_parquet_needs_updating
+from ..automation_conditions import ssen_lv_feeder_monthly_parquet_needs_updating
 from ..core import DNO, lv_feeder_parquet_schema
 from ..dagster_helpers import get_materialisations
 from ..resources.nged import NGEDAPIClient
@@ -39,7 +39,7 @@ from .dno_lv_feeder_files import nged_lv_feeder_files
         "ssen_substation_location_lookup_transformer_load_model",
     ],
     # See also sensors.ssen_lv_feeder_monthly_parquet_sensor
-    automation_condition=lv_feeder_monthly_parquet_needs_updating(
+    automation_condition=ssen_lv_feeder_monthly_parquet_needs_updating(
         AssetSelection.assets("ssen_lv_feeder_files")
     ),
 )

--- a/weave/automation_conditions.py
+++ b/weave/automation_conditions.py
@@ -19,7 +19,7 @@ def needs_updating() -> AutomationCondition:
     ).with_label("needs_updating")
 
 
-def lv_feeder_monthly_parquet_needs_updating(
+def ssen_lv_feeder_monthly_parquet_needs_updating(
     raw_files_asset_selection: AssetSelection,
 ) -> AutomationCondition:
     """
@@ -29,13 +29,14 @@ def lv_feeder_monthly_parquet_needs_updating(
     of waiting for in progress updates in those raw file assets .
     """
     return (
-        AutomationCondition.any_deps_updated()
+        AutomationCondition.in_latest_time_window()
+        & AutomationCondition.any_deps_updated()
         .ignore(raw_files_asset_selection)
         .since_last_handled()
         & ~AutomationCondition.any_deps_missing().ignore(raw_files_asset_selection)
         & ~AutomationCondition.any_deps_in_progress()
         & ~AutomationCondition.in_progress()
-    ).with_label("lv_feeder_monthly_parquet_needs_updating")
+    ).with_label("ssen_lv_feeder_monthly_parquet_needs_updating")
 
 
 def lv_feeder_combined_geoparquet_needs_updating() -> AutomationCondition:

--- a/weave_tests/test_automation.py
+++ b/weave_tests/test_automation.py
@@ -113,18 +113,14 @@ def test_ssen_monthly_files_automation(instance):
     result = evaluate_automation_conditions(
         instance=instance, defs=defs, cursor=result.cursor
     )
-    # Then, we should request updates of all the monthly files
-    start_date = datetime(2024, 2, 1)
+    # Then, we should request updates of the latest two monthly files
     today = datetime.today()
-    months_difference = (today.year - start_date.year) * 12 + (
-        today.month - start_date.month
+    latest_partition = f"{today.year}-{today.month:02d}-01"
+    requested_partitions = result.get_requested_partitions(
+        AssetKey("ssen_lv_feeder_monthly_parquet")
     )
-    expected_partitions = months_difference + 1
-    assert result.total_requested == expected_partitions
-    assert (
-        len(result.get_requested_partitions(AssetKey("ssen_lv_feeder_monthly_parquet")))
-        == expected_partitions
-    )
+    assert result.total_requested == 1
+    assert requested_partitions == set([latest_partition])
 
 
 def test_combined_geoparquet_automation(instance):


### PR DESCRIPTION
This isn't perfect, because we can be in the latest partition and SSEN will still be publishing new data to the previous month, but I don't think it will have a huge effect on the data quality - my suspicion is that they aren't updating all that much each time the postcode lookup is updated.

Fixes #38